### PR TITLE
Consider AngleAxis axis direction for 2D rotation

### DIFF
--- a/minkindr_conversions/include/minkindr_conversions/kindr_msg.h
+++ b/minkindr_conversions/include/minkindr_conversions/kindr_msg.h
@@ -76,7 +76,8 @@ void quaternionMsgToKindr2D(
   kindr::minimal::RotationQuaternionTemplate<Scalar> quat;
   quaternionMsgToEigen(msg, quat.toImplementation());
   const kindr::minimal::AngleAxisTemplate<Scalar> angle_axis(quat);
-  kindr->angle() = angle_axis.angle();
+  const Scalar sign = angle_axis.axis()(2) >= Scalar(0) ? Scalar(1) : Scalar(-1);
+  kindr->angle() = angle_axis.angle() * sign;
 }
 
 // A wrapper for the relevant functions in eigen_conversions.

--- a/minkindr_conversions/include/minkindr_conversions/kindr_msg.h
+++ b/minkindr_conversions/include/minkindr_conversions/kindr_msg.h
@@ -76,8 +76,7 @@ void quaternionMsgToKindr2D(
   kindr::minimal::RotationQuaternionTemplate<Scalar> quat;
   quaternionMsgToEigen(msg, quat.toImplementation());
   const kindr::minimal::AngleAxisTemplate<Scalar> angle_axis(quat);
-  const Scalar sign = angle_axis.axis()(2) >= Scalar(0) ? Scalar(1) : Scalar(-1);
-  kindr->angle() = angle_axis.angle() * sign;
+  kindr->angle() = std::copysign(angle_axis.angle(), angle_axis.axis()(2));
 }
 
 // A wrapper for the relevant functions in eigen_conversions.

--- a/minkindr_conversions/test/kindr_msg_test.cc
+++ b/minkindr_conversions/test/kindr_msg_test.cc
@@ -30,8 +30,7 @@ TEST(KindrMsgTest, poseKindrToMsgToKindr) {
 }
 
 TEST(KindrMsgTest, poseKindr2DToMsgToKindr2D) {
-  std::vector<double> test_rotation_angles_rad {-0.5, 0.5};
-  for( auto const angle_rad : test_rotation_angles_rad) {
+  for(auto const angle_rad : {-0.5, 0.5}) {
     Eigen::Rotation2D<double> rotation(angle_rad);
     const Eigen::Vector2d position = Eigen::Vector2d::Random();
     kindr::minimal::Transformation2D kindr_transform(rotation, position);
@@ -42,7 +41,7 @@ TEST(KindrMsgTest, poseKindr2DToMsgToKindr2D) {
     poseMsgToKindr2D(msg, &output_transform);
 
     EXPECT_NEAR(
-        output_transform.getRotation().angle(), rotation.angle(), kTestTolerance)
+        output_transform.getRotation().angle(), angle_rad, kTestTolerance)
             << "Angle: " << angle_rad;
     EXPECT_NEAR_EIGEN(output_transform.getPosition(), position, kTestTolerance);
   }

--- a/minkindr_conversions/test/kindr_msg_test.cc
+++ b/minkindr_conversions/test/kindr_msg_test.cc
@@ -30,19 +30,22 @@ TEST(KindrMsgTest, poseKindrToMsgToKindr) {
 }
 
 TEST(KindrMsgTest, poseKindr2DToMsgToKindr2D) {
-  static constexpr double kTestRotationAngleRad = 0.5;
-  Eigen::Rotation2D<double> rotation(kTestRotationAngleRad);
-  const Eigen::Vector2d position = Eigen::Vector2d::Random();
-  kindr::minimal::Transformation2D kindr_transform(rotation, position);
+  std::vector<double> test_rotation_angles_rad {-0.5, 0.5};
+  for( auto const angle_rad : test_rotation_angles_rad) {
+    Eigen::Rotation2D<double> rotation(angle_rad);
+    const Eigen::Vector2d position = Eigen::Vector2d::Random();
+    kindr::minimal::Transformation2D kindr_transform(rotation, position);
 
-  geometry_msgs::Pose msg;
-  poseKindr2DToMsg(kindr_transform, &msg);
-  kindr::minimal::Transformation2D output_transform;
-  poseMsgToKindr2D(msg, &output_transform);
+    geometry_msgs::Pose msg;
+    poseKindr2DToMsg(kindr_transform, &msg);
+    kindr::minimal::Transformation2D output_transform;
+    poseMsgToKindr2D(msg, &output_transform);
 
-  EXPECT_NEAR(
-      output_transform.getRotation().angle(), rotation.angle(), kTestTolerance);
-  EXPECT_NEAR_EIGEN(output_transform.getPosition(), position, kTestTolerance);
+    EXPECT_NEAR(
+        output_transform.getRotation().angle(), rotation.angle(), kTestTolerance)
+            << "Angle: " << angle_rad;
+    EXPECT_NEAR_EIGEN(output_transform.getPosition(), position, kTestTolerance);
+  }
 }
 
 TEST(KindrMsgTest, poseMsgToKindr2DFailsForInvalidInputPose) {


### PR DESCRIPTION
The Eigen::AngleAxis [assignment operator](https://gitlab.com/libeigen/eigen/-/blob/master/Eigen/src/Geometry/AngleAxis.h#L164) will make sure that the angle is between [0,pi]. For a pure negative yaw rotation in [-pi,0), the angle axis angle will be positive and the z axis component will be negative.

Previously quaternionMsgToKindr2D() only look at the AngleAxis' angle, producing only rotation about [0,pi].
@fabianbl   Could you have a look at this?